### PR TITLE
アプリケーションの12行目編集しました。

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module ChatSpace
   class Application < Rails::Application
     config.time_zone = 'Tokyo'
+    config.generators do |g|
       g.stylesheets false
       g.javascripts false
       g.helper false


### PR DESCRIPTION
aplication.rbのファイルに、config.time_zone = 'Tokyo'の記述が必要で、
同じ記述でconfig.generators do |g|が同じconfigだったので、削除しエラー文が
発生したので、記述し直しブラウザも反映されたので、ファイルを生成しプルリクエストしました。


